### PR TITLE
Fix docker-compose option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - docker-compose pull
   - docker-compose build
 script:
-  - docker-compose up --exit-code-from erlang-in-anger-pdf-compile
+  - docker-compose up --abort-on-container-exit
 after_success:
   - ./travis/deploy_image.sh
   - ./travis/deploy_pdf.sh


### PR DESCRIPTION
- Travis CIでDockerの警告があったので修正
    - https://travis-ci.org/ymotongpoo/erlang-in-anger/builds/394455782#L574

```
WARNING: using --exit-code-from implies --abort-on-container-exit
```