### PR TITLE
章見出しのデザイン変更と強調のフォントを変更した

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,6 +65,7 @@ RUN apk add --no-cache --virtual .texlive-deps $TEXLIVE_DEPS && \
     tlmgr install latexmk collection-luatex collection-langjapanese \
       collection-fontsrecommended type1cm mdframed needspace fontaxes \
       boondox everyhook svn-prov framed placeins adjustbox collectbox comment && \
+    luaotfload-tool -u -vvv && \
     apk del .texlive-deps
 
 VOLUME ["/workdir"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,8 @@ RUN apk add --no-cache --virtual .texlive-deps $TEXLIVE_DEPS && \
       -profile /tmp/install-tl-unx/texlive.profile && \
     tlmgr install latexmk collection-luatex collection-langjapanese \
       collection-fontsrecommended type1cm mdframed needspace fontaxes \
-      boondox everyhook svn-prov framed placeins adjustbox collectbox comment && \
+      boondox everyhook svn-prov framed placeins adjustbox \
+      collectbox comment fncychap && \
     luaotfload-tool -u -vvv && \
     apk del .texlive-deps
 

--- a/text-ja.tex
+++ b/text-ja.tex
@@ -1,8 +1,32 @@
-\documentclass[autodetect-engine, dvipdfmx-if-dvi, base=11pt, oneside, ja=standard, jafont=sourcehan-jp]{bxjsreport}
+\documentclass[autodetect-engine, dvipdfmx-if-dvi, base=11pt, oneside, ja=standard]{bxjsreport}
 % !TEX encoding = UTF-8 Unicode
 \usepackage{graphicx}
 \usepackage{text}
 \usepackage{comment}
+
+% 日本語フォント設定
+\usepackage[sourcehan-jp, nfssonly, deluxe]{luatexja-preset}
+
+% 強調（\emph）をボールドゴシックに設定
+\let\emph\relax
+\DeclareTextFontCommand{\emph}{\gtfamily\bfseries}
+
+% チャプタータイトルの設定
+\usepackage[Glenn]{fncychap}
+\ChTitleVar{\bfseries\Large\mcfamily\rmfamily}
+\makeatletter
+\renewcommand{\DOCH}{%
+  \settoheight{\myhi}{\CTV\FmTi{Test}}
+  \setlength{\py}{\baselineskip}
+  \addtolength{\py}{\RW}
+  \addtolength{\py}{\myhi}
+  \setlength{\pyy}{\py}
+  \addtolength{\pyy}{-1\RW}
+  \raggedright
+  \CNV\FmN{\@chapapp}\space\CNoV\thechapter\CNV\FmN{\@chappos}
+  \hskip 3pt\mghrulefill{\RW}\rule[-1\pyy]{2\RW}{\py}\par\nobreak
+}
+\makeatother
 
 % GitのコミットIDを埋め込む用
 \input{vc.tex}


### PR DESCRIPTION
### 概要

1. `Dockerfile`でフォントの準備を行うようにし、`docker-compose up`によるコンパイルを高速化した
2. 章見出しのデザインを変更した
3. 強調（`\emph`）のフォントを変更した

### 詳細

#### `Dockerfile`の変更

LuaLaTeXはフォントを利用する際に、フォント情報をLuaプログラム（DSL）として出力しキャッシュする。従来はこのキャッシュ生成を`docker-compose up`のたびに実行していたが、コンパイル高速化のためDockerのイメージ作成の際に実行するようにした。

#### 章見出しのデザインを変更

こんな感じにしてみました。

![image](https://user-images.githubusercontent.com/612043/41701623-1f57d6a4-7568-11e8-8ecd-015ea6da2712.png)

なんとなくLaTeXっぽいところから卒業したか？

#### 強調（`\emph`）のフォント変更

賛否がありそうだが、今までは`\emph`で強調したとしてもゴシック体になるだけでボールドにはしていなかったので、ここではゴシック体かつボールドにするようにした。

![image](https://user-images.githubusercontent.com/612043/41701696-581b17ee-7568-11e8-8b15-2d764920ff90.png)

