### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Erlang in Angerの翻訳用レポジトリです。オリジナルのREADMEは[�
 4. 担当部分が終わったら `japanese` ブランチにmerge。心配ならpull-requestを出してください。(みんなでレビューしましょう)
 5. 以下2-4の繰り返し。
 
+また、pull-requestを出してCIに通った場合は次のリポジトリにPDFがアップロードされます。
+
+- https://github.com/y-yu/erlang-in-anger-pr
+
 ## レビュー
 訳がおかしいなと思ったら適宜Issueを立ててください。(TODO: Issueテンプレートの作成)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # README
-![PDF Build on Travis CI](https://travis-ci.org/ymotongpoo/erlang-in-anger.svg?branch=japanese)
-Erlang in Angarの翻訳用レポジトリです。オリジナルのREADMEは[こちら](./README.en.md)を参照してください。
+[![Build Status](https://travis-ci.org/ymotongpoo/erlang-in-anger.svg?branch=japanese)](https://travis-ci.org/ymotongpoo/erlang-in-anger)
+
+Erlang in Angerの翻訳用レポジトリです。オリジナルのREADMEは[こちら](./README.en.md)を参照してください。
 
 # 最新版
 * https://github.com/ymotongpoo/erlang-in-anger/blob/gh-pages/text-ja.pdf


### PR DESCRIPTION
- typo修正（`Angar` → `Anger`）
- Travis CIのステータス画像をTravisへのリンクへ修正