### PR TITLE
GitHub Pages上のPDFへのURLをREADMEに追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 Erlang in Angerの翻訳用レポジトリです。オリジナルのREADMEは[こちら](./README.en.md)を参照してください。
 
 # 最新版
+* https://ymotongpoo.github.io/erlang-in-anger/text-ja.pdf
 * https://github.com/ymotongpoo/erlang-in-anger/blob/gh-pages/text-ja.pdf
 
 # Contribution


### PR DESCRIPTION
- GitHubのPDFビュアーでは一部しかPDFを読むことができず、ブラウザで読みたい人にとって不便な気がしたのでGitHub PagesのPDFリンクを追加した