### PR TITLE
欧文フォントを変更しヘッダーを洗練させた

### DIFF
--- a/001-introduction-ja.tex
+++ b/001-introduction-ja.tex
@@ -1,8 +1,5 @@
 %\chapter*{Introduction}
-\chapter*{はじめに}
-\markboth{\MakeUppercase{Introduction}}{}
-%\addcontentsline{toc}{chapter}{Introduction}
-\addcontentsline{toc}{chapter}{はじめに}
+\chapter{はじめに}
 \label{chap:introduction}
 
 %\section*{On Running Software}

--- a/201-conclusion-ja.tex
+++ b/201-conclusion-ja.tex
@@ -1,8 +1,5 @@
 %\chapter*{Conclusion}
-\chapter*{おわりに}
- \markboth{\MakeUppercase{Conclusion}}{}
-\addcontentsline{toc}{chapter}{Conclusion}
-
+\chapter{おわりに}
 
 %Maintaining and debugging software never ends. New bugs and confusing behaviours will keep popping up around the place all the time. There would probably be enough stuff out there to fill out dozens of manuals like this one, even when dealing with the cleanest of all systems.
 ソフトウェアの運用とデバッグは決して終わることはありません。新しいバグやややこしい動作がつねにあちこちに出現しつづけるでしょう。

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN apk add --no-cache --virtual .texlive-deps $TEXLIVE_DEPS && \
     tlmgr install latexmk collection-luatex collection-langjapanese \
       collection-fontsrecommended type1cm mdframed needspace fontaxes \
       boondox everyhook svn-prov framed placeins adjustbox \
-      collectbox comment fncychap && \
+      collectbox fncychap sourcesanspro sourceserifpro cm-unicode && \
     luaotfload-tool -u -vvv && \
     apk del .texlive-deps
 

--- a/text-ja.tex
+++ b/text-ja.tex
@@ -1,8 +1,12 @@
-\documentclass[autodetect-engine, dvipdfmx-if-dvi, base=11pt, oneside, ja=standard]{bxjsreport}
+\documentclass[autodetect-engine, dvipdfmx-if-dvi, base=11pt, ja=standard, openany]{bxjsbook}
 % !TEX encoding = UTF-8 Unicode
 \usepackage{graphicx}
 \usepackage{text}
-\usepackage{comment}
+
+% 欧文のフォント設定
+\usepackage[default, regular, bold]{sourcesanspro}
+\usepackage[default, regular, bold]{sourceserifpro}
+\setmonofont{CMU Typewriter Text}
 
 % 日本語フォント設定
 \usepackage[sourcehan-jp, nfssonly, deluxe]{luatexja-preset}
@@ -11,8 +15,12 @@
 \let\emph\relax
 \DeclareTextFontCommand{\emph}{\gtfamily\bfseries}
 
+% 見出しのフォントをゴシックに設定
+\renewcommand{\headfont}{\gtfamily\sffamily}
+
 % チャプタータイトルの設定
 \usepackage[Glenn]{fncychap}
+\ChNameVar{\Large\headfont}
 \ChTitleVar{\bfseries\Large\mcfamily\rmfamily}
 \makeatletter
 \renewcommand{\DOCH}{%
@@ -31,6 +39,9 @@
 % GitのコミットIDを埋め込む用
 \input{vc.tex}
 
+% ページレイアウト
+\geometry{centering}
+
 %%% Cover
 
 \title{Stuff Goes Bad:\protect\\ Erlang in Anger}
@@ -42,6 +53,7 @@
 }
 
 \begin{document}
+
 \frontmatter
 
 \maketitle
@@ -99,6 +111,9 @@
 %% Kernel Polling
 
 %%
+
+\backmatter
+
 \bookmarksetup{startatroot} % Split conclusion from previous Part
 \addtocontents{toc}{\bigskip} % Add space in ToC
 \include{201-conclusion-ja}


### PR DESCRIPTION
## 概要

- 「はじまり」と「おわりに」の調整した
- 欧文フォントをSourceHanへ変更した
- ページヘッダーを洗練させた

## プレビュー

- https://y-yu.github.io/erlang-in-anger-pr/feature/change-style/0f9838d0f75fd8c9726958cadbc07947735ec66a.pdf

## 詳細

### 「はじまり」と「おわりに」の調整

- 「はじめに」と「おわりに」は`\chapter*`を利用したのちに`\addcontentsline`で目次を生成していたが、これらは`\frontmatter`と`\backmatter`を利用した方法に置き換えた
    - 本は`\frontmatter`、`\mainmatter`そして`\backmatter`などから構成され、`\backmatter`は本文の後に続く文章を示す
    - 「おわりに」は`\backmatter`にあるべき章であり、かつ`\backmatter`と書くとLaTeXが自動で章番号を落すので、そちらへ変更した
- 同様に「はじめに」も`\frontmatter`にし、章見出しは`\chapter`で与えた

### 欧文フォントをSourceHanへ変更

- 欧文フォントは特に設定されていなかったので、LaTeXのデフォルトが利用されていた
- ところが、日本語のボールドと太さが違いすぎて微妙だったので、源ノ系日本語フォントと同じ出自であるSourceHanフォントへ変更した
- また、この副作用としてアンダースコアが洗練された
- ただし、ソースコードのレイアウトが崩壊することを防ぐために、ソースコードのフォントは似たようなフォントのままにした

#### Before

- ![image](https://user-images.githubusercontent.com/612043/41811709-aea8250a-774f-11e8-8ad4-e735f688c1f4.png)
- ![image](https://user-images.githubusercontent.com/612043/41811715-d1aeac86-774f-11e8-8119-5ca73342c007.png)

-----------------

#### After

- ![image](https://user-images.githubusercontent.com/612043/41811711-bb7eaea2-774f-11e8-9592-930275319dbc.png)
- ![image](https://user-images.githubusercontent.com/612043/41811721-db1b95f4-774f-11e8-8dc5-048d90ef88c5.png)

### ページヘッダーの洗練

- これまではレポート（報告書）用のパッケージを利用していたが、本のためのパッケージへ変更した
- ただ、この本はPDFのまま読まれることを考慮して、中央寄せは維持した
    - 一般の本は背表紙側の余白が広めになるように、偶数・奇数ページで非対称な余白レイアウトだが、この本ではパソコンで読むことを考慮して偶数・奇数ページに関わらず左右対象である