### PR TITLE
TeXLiveに必要なglibcのインスール方法を変更した

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM frolvlad/alpine-glibc:alpine-3.10
+FROM alpine:3.11
 
-MAINTAINER yyu <yyu [at] mental.poker>
+LABEL maintainer="Yoshimura Yuu <yyu [at] mental.poker>"
 
 ENV TEXLIVE_DEPS \
     xz \
@@ -23,7 +23,7 @@ ENV PERSISTENT_DEPS \
     bash \
     git
 
-ENV PATH $TEXLIVE_PATH/bin/x86_64-linux:$PATH
+ENV PATH $TEXLIVE_PATH/bin/x86_64-linuxmusl:$PATH
 
 RUN apk upgrade --update
 
@@ -48,6 +48,11 @@ RUN mkdir -p $FONT_PATH && \
 RUN apk --no-cache add tzdata && \
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     echo 'Asia/Tokyo' > /etc/timezone
+
+# Install glibc
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk && \
+    apk add glibc-2.31-r0.apk
 
 # Install TeXLive
 RUN apk add --no-cache --virtual .texlive-deps $TEXLIVE_DEPS && \


### PR DESCRIPTION
- こまではAlpine Linuxイメージを改造した`frolvlad/alpine-glibc:alpine-3.10`を利用していた
- しかしhttps://github.com/scala-text/scala_text_pdf/pull/9 でやった方法で公式のAlpine Linuxのイメージを利用できることがわかった
- そこでglibcは自力でいれることとして、公式のAlpine Linuxのイメージとした
- ついでにAlpine Linuxも3.11系へアップデートした