### PR TITLE
glibcのインストールは不要なのでやめた

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,11 +49,6 @@ RUN apk --no-cache add tzdata && \
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     echo 'Asia/Tokyo' > /etc/timezone
 
-# Install glibc
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk && \
-    apk add glibc-2.31-r0.apk
-
 # Install TeXLive
 RUN apk add --no-cache --virtual .texlive-deps $TEXLIVE_DEPS && \
     mkdir /tmp/install-tl-unx && \


### PR DESCRIPTION
- https://github.com/rust-lang-ja/book-ja-pdf/pull/5 と同様の対応