### PR TITLE
Fix quote style following the LaTeX convention

### DIFF
--- a/104-connecting-ja.tex
+++ b/104-connecting-ja.tex
@@ -18,7 +18,7 @@
 私がもっと興味があるのは、事態が既に悪化していて、その事態に対処する機能が存在しない場合です。
 
 %Erlang uses something closer to an "interactor" than a REPL.
-ErlangはREPLというより"インタラクタ"に近いものを使っています。
+ErlangはREPLというより``インタラクタ''に近いものを使っています。
 %Basically, a regular Erlang virtual machine does not need a REPL, and will happily run byte code and stick with that, no shell needed.
 基本的には、Erlang仮想マシンはREPLを必要とせず、バイトコードがうまい具合に動作するよう専念すれば良いのです。シェルの必要はありませんね。
 %However, because of how it works with concurrency and multiprocessing, and good support for distribution, it is possible to have in-software REPLs that run as arbitrary Erlang processes.


### PR DESCRIPTION
- LaTeXでは文章中の`"`（ダブルクォート）を<code>``</code>と`''`で表現する
    - current:
        - <img src="https://user-images.githubusercontent.com/612043/103455504-10787c80-4d31-11eb-8184-fe4e8b228892.png" width="20%" />
    - **new**:
        - <img src="https://user-images.githubusercontent.com/612043/103455539-51709100-4d31-11eb-9239-4d74dc0932b9.png" width="20%" />
- `git grep`したところ、一箇所だけ`"`を文章中で利用していたため置換した
    - 他の箇所 👇 は文章中ではないためこのままでOK 🙆‍♀️ 

```console
$ git grep '".*"' *-ja.tex
001-introduction-ja.tex:%Erlang, on the other hand, takes the approach that failures will happen no matter what, whether they're developer-, operator-, or hardware-related. It is rarely practical or even possible to get rid of all errors in a program or a system.\footnote{life-critical systems are usually excluded from this category} If you can deal with some errors rather than preventing them at all cost, then most undefined behaviours of a program can go in that "deal with it" approach.
001-introduction-ja.tex:%This is where the "Let it Crash"\footnote{Erlang people now seem to favour "let it fail", given it makes people far less nervous.} idea comes from: Because you can now deal with failure, and because the cost of weeding out all of the complex bugs from a system before it hits production is often prohibitive, programmers should only deal with the errors they know how to handle, and leave the rest for another process (a supervisor) or the virtual machine to deal with.
101-diving-ja.tex:%"Read the source" is one of the most annoying things to be told, but dealing with Erlang programmers, you'll have to do it often. Either the documentation for a library will be incomplete, outdated, or just not there. In other cases, Erlang programmers are a bit similar to Lispers in that they will tend to write libraries that will solve their problems and not really test or try them in other circumstances, leaving it to you to extend or fix issues that arise in new contexts.
102-building-ja.tex:  {myapp,"1.0.0"},
102-building-ja.tex:  {myapp, {git, "git://github.com/user/myapp.git", {ref, "aef728"}}},
102-building-ja.tex:  {myapp, {git, "https://github.com/user/myapp.git", {branch, "master"}}},
102-building-ja.tex:  {myapp, {hg, "https://othersite.com/user/myapp", {tag, "3.0.0"}}}
102-building-ja.tex:  {release, {demo, "1.0.0"},
103-overload-ja.tex:%When there is \emph{any} point of your program that ends up being a central hub for receiving messages, lengthy tasks should be moved out of there if possible. Handling predictable overload\footnote{Something you know for a fact gets overloaded in production} situations by adding more processes — which either handle the blocking operations or instead act as a buffer while the "main" process blocks — is often a good idea.
103-overload-ja.tex:%This means that when you introduce synchronous behaviour deep in the system, you'll possibly need to handle back-pressure, level by level, until you end up at the system's edges and can tell the user, "please slow down."
103-overload-ja.tex:%I've found that in practice, dropping without regard to the specifics of the message works rather well, but each application has its share of unique compromises that can be acceptable or not\footnote{Old papers such as \href{http://research.microsoft.com/en-us/um/people/blampson/33-hints/webpage.html}{Hints for Computer System Designs} by Butler W. Lampson recommend dropping messages: "Shed load to control demand, rather than allowing the system to become overloaded." The paper also mentions that  "A system cannot be expected to function well if the demand for any resource exceeds two-thirds of the capacity, unless the load can be characterized extremely well." adding that "The only systems in which cleverness has worked are those with very well-known loads."}.
103-overload-ja.tex:%There are also cases where the data is sent to you in a "fire and forget" manner — the entire system is part of an asynchronous pipeline — and it proves difficult to provide feedback to the end-user about why some requests were dropped or are missing. If you can reserve a special type of message that accumulates dropped responses and tells the user "\var{N} messages were dropped for reason \var{X}", that can, on its own, make the compromise far more acceptable to the user. This is the choice that was made with Heroku's \href{https://devcenter.heroku.com/articles/logplex}{logplex} log routing system, which can spit out \href{https://devcenter.heroku.com/articles/error-codes\#l10-drain-buffer-overflow}{L10 errors}, alerting the user that a part of the system can't deal with all the volume right now.
104-connecting-ja.tex:%Erlang uses something closer to an "interactor" than a REPL.
104-connecting-ja.tex:2> ssh:daemon(8989, [{system_dir, "/tmp/ssh"},
104-connecting-ja.tex:2>                   {user_dir, "/home/ferd/.ssh"}]).
104-connecting-ja.tex:%This can be done by starting Erlang with \app{run\_erl}, which wraps Erlang in a named pipe\footnote{\command{"erl"} is the command being run. Additional arguments can be added after it. For example \command{"erl +K true"} will turn kernel polling on.}:
104-connecting-ja.tex:これはErlangを\app{run\_erl}で起動すれば実現できます。\app{run\_erl}が名前付きパイプの中にErlangをラップしてくれます\footnote{\command{"erl"}が実行されるコマンドです。引数はその後に追加できます。例えば\command{"erl +K true"}でカーネルポーリングが有効になります。}。
104-connecting-ja.tex:$ run_erl /tmp/erl_pipe /tmp/log_dir "erl"
105-runtime-metrics-ja.tex:[{"tcp_inet",21480},
105-runtime-metrics-ja.tex: {"efile",2},
105-runtime-metrics-ja.tex: {"udp_inet",2},
105-runtime-metrics-ja.tex: {"0/1",1},
105-runtime-metrics-ja.tex: {"2/2",1},
105-runtime-metrics-ja.tex: {"inet_gethost 4 ",1}]
105-runtime-metrics-ja.tex:%The \expression{efile} type is for files, while \expression{"0/1"} and \expression{"2/2"} are file descriptors for standard I/O channels (\emph{stdin} and \emph{stdout}) and standard error channels (\emph{stderr}), respectively.
105-runtime-metrics-ja.tex:\expression{efile}タイプはファイルのためのもので、\expression{"0/1"}と\expression{"2/2"}はそれぞれ、標準入出力チャンネル (\emph{stdin}と\emph{stdout})と標準エラー出力チャンネル(\emph{stderror})へのファイルディスクリプタを表します。
105-runtime-metrics-ja.tex:1> recon:info("<0.12.0>").
105-runtime-metrics-ja.tex:                                  [{file,"gen_server.erl"},{line,358}]},
105-runtime-metrics-ja.tex:                                  [{file,"proc_lib.erl"},{line,239}]}]}]},
105-runtime-metrics-ja.tex:%For the sake of convenience, \expression{recon:info/1} will accept any pid-like first argument and handle it: literal pids, strings (\expression{"<0.12.0>"}), registered atoms, global names (\expression{\{global, Atom\}}), names registered with a third-party registry (e.g. with \otpapp{gproc}: \expression{\{via, gproc, Name\}}), or tuples (\expression{\{0,12,0\}}). The process just needs to be local to the node you're debugging.
105-runtime-metrics-ja.tex:使用しやすいよう、\expression{recon:info/1}はプロセスid、文字列\expression{"<0.12.0>"}、名前として登録されたアトム、グローバルネーム\expression{\{global, Atom\}}、サードパーティーのレジストリで登録された名前(例えば\otpapp{gproc}による\expression{\{via, gproc, Name\}})、タプル\expression{\{0,12,0\}}といったpidライクな最初の引数を受け取ってそれを処理します。このプロセスはデバッグ対象のノードにある必要があります。
105-runtime-metrics-ja.tex:			%\item[\expression{name}] type of the port — with names such as \expression{"tcp\_inet"}, \expression{"udp\_inet"}, or \expression{"efile"}, for example.
105-runtime-metrics-ja.tex:      \item[\expression{name}] ポートのタイプです。例えば、\expression{"tcp\_inet"}、\expression{"udp\_inet"}、\expression{"efile"}などの名前で表します。
105-runtime-metrics-ja.tex:1> recon:port_info("#Port<0.818>").
105-runtime-metrics-ja.tex:[{meta,[{id,6544},{name,"tcp_inet"},{os_pid,undefined}]},
105-runtime-metrics-ja.tex:%Which suggest some ports are doing only input and eating lots of bytes. You can then use \function{recon:port\_info("\#Port<0.6821166>")} to dig in and find who owns that socket, and what is going on with it.
105-runtime-metrics-ja.tex:これは、いくつかのポートがただ受信しているだけで沢山のバイトを食い荒らしていることを示してします。そして\function{recon:port\_info("\#Port<0.6821166>")} を使って深掘り、誰がそのソケットを所有しているか、何が起こっているかを見つけることができます。
106-crash-dumps-ja.tex:(of type "old_heap").
106-crash-dumps-ja.tex:%If it looks more or less reasonable, head towards the "Memory" section of the dump and check if a type (ETS or Binary, for example) seems to be fairly large. They may point towards resource leaks you hadn't expected.
107-memory-leaks-ja.tex:% Whenever someone calls for help saying "oh no, my nodes are crashing", the first step is always to ask for data. Interesting questions to ask and pieces of data to consider are:
108-cpu-ja.tex:            io:format("monitor=long_schedule pid=~p info=~p~n", [Pid, Info]);
108-cpu-ja.tex:            io:format("monitor=long_gc pid=~p info=~p~n", [Pid, Info])
109-tracing-ja.tex:%    Which processes to trace. Valid options is any of \term{all}, \term{new}, \term{existing}, or a process descriptor (\expression{\{A,B,C\}}, \expression{"<A.B.C>"}, an atom representing a name, \expression{\{global, Name\}}, \expression{\{via, Registrar, Name\}}, or a pid). It's also possible to specify more than one by putting them in a list.
109-tracing-ja.tex:	トレースするプロセスの指定です。有効なオプションは \term{all}, \term{new}, \term{existing}, あるいはプロセスディスクリプタ(\expression{\{A,B,C\}}, \expression{"<A.B.C>"}, 名前をあらわすアトム、\expression{\{global, Name\}}, \expression{\{via, Registrar, Name\}}, あるいは pid)のどれかです。リストにすることで、複数指定することも可能です。
109-tracing-ja.tex:%With these options, the multiple ways to pattern match on specific calls for specific functions and whatnot, a lot of development and production issues can more quickly be diagnosed. If the idea ever comes to say "hm, maybe I should add more logging there to see what could cause that funny behaviour", tracing can usually be a very fast shortcut to get the data you need without deploying any code or altering its readability.
```